### PR TITLE
docs: Improve MCP client setup instructions with agent-specific dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ To allow an MCP client (like Claude Desktop or a custom client) to interact with
 
 The GhidraMCP server runs within Ghidra itself when the extension is active. It exposes an HTTP endpoint for stateless MCP communication.
 
-Add the following configuration to your MCP client's settings (e.g., `claude_desktop_config.json` for Claude Desktop). Adjust the key (`"ghidra"` in this example) as needed:
+### Agent-Specific Setup Instructions
+
+<details>
+<summary><strong>🤖 Claude Desktop</strong></summary>
+
+For Claude Desktop, add the following configuration to your `claude_desktop_config.json` file. Adjust the key (`"ghidra"` in this example) as needed:
 
 ```json
 {
@@ -140,6 +145,68 @@ Add the following configuration to your MCP client's settings (e.g., `claude_des
 	}
 }
 ```
+
+**Configuration file location:**
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+After updating the configuration, restart Claude Desktop to apply the changes.
+
+</details>
+
+<details>
+<summary><strong>🔧 Claude Code (CLI)</strong></summary>
+
+For Claude Code, use the following command to add the GhidraMCP server:
+
+```bash
+claude mcp add ghidra "http://127.0.0.1:8080/mcp" --transport http
+```
+
+This will automatically configure the MCP server connection for Claude Code.
+
+</details>
+
+<details>
+<summary><strong>⚡ Cursor</strong></summary>
+
+For Cursor, you can use the one-click installation button above, or manually add to your MCP configuration:
+
+```json
+{
+	"mcpServers": {
+		"ghidra": {
+			"url": "http://127.0.0.1:8080/mcp"
+		}
+	}
+}
+```
+
+**Configuration file location:**
+- `~/.cursor/mcp_settings.json` (or your Cursor configuration directory)
+
+</details>
+
+<details>
+<summary><strong>🛠️ Custom MCP Client</strong></summary>
+
+For custom MCP clients or other implementations, use the standard MCP configuration format:
+
+```json
+{
+	"mcpServers": {
+		"ghidra": {
+			"url": "http://127.0.0.1:8080/mcp",
+			"transport": "http"
+		}
+	}
+}
+```
+
+The server supports standard MCP over HTTP protocol.
+
+</details>
 
 ---
 


### PR DESCRIPTION
## Summary

This PR improves the MCP client setup instructions in the README.md by organizing them into agent-specific dropdowns for better readability and user experience.

## Changes

- Agent-specific setup instructions organized in collapsible dropdowns:
  - Claude Desktop - JSON configuration with platform-specific file locations
  - Claude Code (CLI) - CLI command for adding GhidraMCP server
  - Cursor - Manual configuration option alongside one-click installation
  - Custom MCP Client - Standard MCP configuration format

- Enhanced user guidance:
  - Platform-specific configuration file locations (Windows, macOS, Linux)
  - Clear restart requirements for Claude Desktop
  - Better organization with collapsible sections

## Benefits

- Improved readability - Users can quickly find instructions for their specific agent
- Better user experience - Collapsible dropdowns reduce visual clutter
- Comprehensive coverage - Instructions for all major MCP clients
- Platform awareness - Clear guidance for different operating systems

Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks README MCP client setup into agent-specific collapsible sections with examples, file paths, and a CLI command.
> 
> - **Documentation (README)**:
>   - **MCP Client Setup**: Reorganized into agent-specific collapsible sections.
>     - Claude Desktop: JSON config snippet, platform-specific config file locations, restart note.
>     - Claude Code (CLI): `claude mcp add ghidra` command with HTTP transport.
>     - Cursor: Manual JSON config and config file path.
>     - Custom MCP Client: Standard MCP JSON with explicit `transport` field.
>   - Clarifies server uses HTTP endpoint for stateless MCP communication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab62cac700bcba886e9f087e9acbd10f9e8dc922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->