### PR TITLE
Update Cursor install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 </p> -->
 
 <div align="center">
-  [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=ghidra&config=eyJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODAvbWNwIn0%3D)
+
+  [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=ghidra&config=eyJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODAvbWNwIn0%3D)
+
 </div>
 <h1 align="center">GhidraMCP</h1>
 


### PR DESCRIPTION
- Added blank lines to force markdown parsing
- Changed to deeplink (https://cursor.com/docs/context/mcp/install-links)