### PR TITLE
fix: show version in extension info

### DIFF
--- a/src/main/resources/extension.properties
+++ b/src/main/resources/extension.properties
@@ -1,6 +1,6 @@
 name=${project.name}
-description=${project.description}
+description=${project.description} (Version ${project.version})
 author=TheMixedNuts
 createdOn=2025-05-01
-version=${ghidra.version}
+version=${project.version}
 ghidraVersion=${ghidra.version}


### PR DESCRIPTION
Fixes #12

This PR updates the extension.properties file to:
- Use \\\ instead of \\\ for the version field
- Include the version in the extension description so it's visible in Ghidra's extension manager UI

This allows users to easily see which version of the extension they have installed when checking in Ghidra.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show project version in the extension description and switch `version` to `${project.version}`.
> 
> - **Extension metadata (`src/main/resources/extension.properties`)**:
>   - Update `description` to include the project version: `description=${project.description} (Version ${project.version})`.
>   - Set `version` to use the project version: `version=${project.version}` (replaces `ghidra.version`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b645be641279909309e7445a923cc3f1e7c50622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->